### PR TITLE
fix: use Firestore timestamps for dashboard queries

### DIFF
--- a/app.js
+++ b/app.js
@@ -130,8 +130,8 @@ async function loadDashboardData() {
 
     const appointmentsSnapshot = await db
       .collection('appointments')
-      .where('date', '>=', today)
-      .where('date', '<', tomorrow)
+      .where('date', '>=', firebase.firestore.Timestamp.fromDate(today))
+      .where('date', '<', firebase.firestore.Timestamp.fromDate(tomorrow))
       .get();
 
     document.getElementById('todayAppointments').textContent =


### PR DESCRIPTION
## Summary
- ensure dashboard uses Firestore timestamps when filtering today's appointments

## Testing
- `npm run format:check`
- `npm run check:console`


------
https://chatgpt.com/codex/tasks/task_e_68955d74bbe4832ba8d1869f2c30d5d0