### PR TITLE
feat: calcular festivos con ley emiliani

### DIFF
--- a/ai_predictions.js
+++ b/ai_predictions.js
@@ -487,6 +487,25 @@ class AIHealthAnalytics {
     return 'normal';
   }
 
+  async getHolidayFactor(days = 30) {
+    const today = new Date();
+    const endDate = new Date();
+    endDate.setDate(today.getDate() + days);
+
+    const holidays = ColombianHolidays.getHolidaysRange(
+      today.getFullYear(),
+      endDate.getFullYear()
+    ).map((d) => new Date(d));
+
+    const upcoming = holidays.filter((d) => d >= today && d <= endDate).length;
+
+    return 1 - upcoming / days;
+  }
+
+  async isHoliday(date) {
+    return ColombianHolidays.isHoliday(date);
+  }
+
   generateDemandInsights(predictions, patterns) {
     const insights = [];
 

--- a/calendar_enhancements.js
+++ b/calendar_enhancements.js
@@ -14,6 +14,11 @@ const FLATPICKR_CONFIG = {
   monthSelectorType: 'dropdown',
 };
 
+function getUpcomingColombianHolidays() {
+  const year = new Date().getFullYear();
+  return ColombianHolidays.getHolidaysRange(year, year + 1);
+}
+
 // Initialize Flatpickr for all date inputs
 function initializeFlatpickr() {
   // Set Spanish locale
@@ -61,7 +66,7 @@ function enhanceDateInputs() {
           return date.getDay() === 0;
         },
         // Disable Colombian holidays
-        ...getColombianHolidays(),
+        ...getUpcomingColombianHolidays(),
       ],
       onReady: function (selectedDates, dateStr, instance) {
         // Add quick select buttons
@@ -186,7 +191,7 @@ function addQuickSelectButtons(instance) {
 
 // Add holiday indicator to calendar
 function addHolidayIndicator(instance) {
-  const holidays = getColombianHolidays();
+  const holidays = getUpcomingColombianHolidays();
 
   instance.config.onDayCreate = function (dObj, dStr, fp, dayElem) {
     const dateStr = moment(dayElem.dateObj).format('YYYY-MM-DD');
@@ -788,38 +793,9 @@ function getServiceColor(serviceType) {
   return colors[serviceType] || '#16A34A';
 }
 
-// Get Colombian holidays for current and next year
-function getColombianHolidays() {
-  const currentYear = new Date().getFullYear();
-  const holidays = [];
-
-  // Holidays for current year and next year
-  [currentYear, currentYear + 1].forEach((year) => {
-    holidays.push(
-      `${year}-01-01`, // Año Nuevo
-      `${year}-01-08`, // Reyes Magos (aproximado)
-      `${year}-03-25`, // San José (aproximado)
-      `${year}-05-01`, // Día del Trabajo
-      `${year}-06-03`, // Corpus Christi (aproximado)
-      `${year}-06-10`, // Sagrado Corazón (aproximado)
-      `${year}-07-01`, // San Pedro y San Pablo (aproximado)
-      `${year}-07-20`, // Independencia
-      `${year}-08-07`, // Batalla de Boyacá
-      `${year}-08-19`, // Asunción (aproximado)
-      `${year}-10-14`, // Día de la Raza (aproximado)
-      `${year}-11-04`, // Todos los Santos (aproximado)
-      `${year}-11-11`, // Independencia de Cartagena (aproximado)
-      `${year}-12-25` // Navidad
-    );
-  });
-
-  return holidays;
-}
-
 // Check if date is holiday
 function isHoliday(date) {
-  const dateStr = moment(date).format('YYYY-MM-DD');
-  return getColombianHolidays().includes(dateStr);
+  return ColombianHolidays.isHoliday(date);
 }
 
 // Calendar enhancement helper functions

--- a/colombian_holidays.js
+++ b/colombian_holidays.js
@@ -1,0 +1,79 @@
+(function (global) {
+  function calculateEaster(year) {
+    const a = year % 19;
+    const b = Math.floor(year / 100);
+    const c = year % 100;
+    const d = Math.floor(b / 4);
+    const e = b % 4;
+    const f = Math.floor((b + 8) / 25);
+    const g = Math.floor((b - f + 1) / 3);
+    const h = (19 * a + b - d - g + 15) % 30;
+    const i = Math.floor(c / 4);
+    const k = c % 4;
+    const l = (32 + 2 * e + 2 * i - h - k) % 7;
+    const m = Math.floor((a + 11 * h + 22 * l) / 451);
+    const month = Math.floor((h + l - 7 * m + 114) / 31);
+    const day = 1 + ((h + l - 7 * m + 114) % 31);
+    return new Date(year, month - 1, day);
+  }
+
+  function addDays(date, days) {
+    const result = new Date(date);
+    result.setDate(result.getDate() + days);
+    return result;
+  }
+
+  function emiliani(date) {
+    const day = date.getDay();
+    if (day === 1) return date;
+    const diff = day === 0 ? 1 : 8 - day;
+    return addDays(date, diff);
+  }
+
+  function format(date) {
+    return date.toISOString().split('T')[0];
+  }
+
+  function getHolidaysByYear(year) {
+    const easter = calculateEaster(year);
+    return [
+      format(new Date(year, 0, 1)),
+      format(new Date(year, 4, 1)),
+      format(new Date(year, 6, 20)),
+      format(new Date(year, 7, 7)),
+      format(new Date(year, 11, 8)),
+      format(new Date(year, 11, 25)),
+      format(emiliani(new Date(year, 0, 6))),
+      format(emiliani(new Date(year, 2, 19))),
+      format(emiliani(new Date(year, 5, 29))),
+      format(emiliani(new Date(year, 7, 15))),
+      format(emiliani(new Date(year, 9, 12))),
+      format(emiliani(new Date(year, 10, 1))),
+      format(emiliani(new Date(year, 10, 11))),
+      format(addDays(easter, -3)),
+      format(addDays(easter, -2)),
+      format(emiliani(addDays(easter, 39))),
+      format(emiliani(addDays(easter, 60))),
+      format(emiliani(addDays(easter, 68))),
+    ];
+  }
+
+  function getHolidaysRange(startYear, endYear) {
+    const holidays = [];
+    for (let y = startYear; y <= endYear; y++) {
+      holidays.push(...getHolidaysByYear(y));
+    }
+    return holidays;
+  }
+
+  function isHoliday(date) {
+    const dateObj = date instanceof Date ? date : new Date(date);
+    return getHolidaysByYear(dateObj.getFullYear()).includes(format(dateObj));
+  }
+
+  global.ColombianHolidays = {
+    getHolidaysByYear,
+    getHolidaysRange,
+    isHoliday,
+  };
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/index.html
+++ b/index.html
@@ -2056,6 +2056,7 @@ _Responde STOP para no recibir más mensajes_</textarea
     <script src="siigo_integration.js"></script>
     <script src="whatsapp_automation.js"></script>
     <script src="whatsapp_functions.js"></script>
+    <script src="colombian_holidays.js"></script>
     <script src="ai_predictions.js"></script>
     <script src="patient_sync.js"></script>
 


### PR DESCRIPTION
## Summary
- add Colombian holiday calculator implementing Ley Emiliani and moving dates
- update calendar widgets and AI predictions to use holiday data

## Testing
- `npx prettier --check ai_predictions.js calendar_enhancements.js index.html colombian_holidays.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689560120f10832b87a29e071903ac15