### PR TITLE
refactor calendar initialization

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,7 +8,6 @@ const db = firebase.firestore();
 
 // Global variables
 let currentUser = null;
-let calendar = null;
 let appointmentsChart = null;
 let servicesChart = null;
 
@@ -277,82 +276,82 @@ async function loadCharts() {
       date.setDate(date.getDate() - i);
       date.setHours(0, 0, 0, 0);
 
-    const nextDate = new Date(date);
-    nextDate.setDate(nextDate.getDate() + 1);
+      const nextDate = new Date(date);
+      nextDate.setDate(nextDate.getDate() + 1);
 
-    const snapshot = await db
-      .collection('appointments')
-      .where('date', '>=', date)
-      .where('date', '<', nextDate)
-      .get();
+      const snapshot = await db
+        .collection('appointments')
+        .where('date', '>=', date)
+        .where('date', '<', nextDate)
+        .get();
 
-    last7Days.push(
-      date.toLocaleDateString('es', { weekday: 'short', day: 'numeric' })
-    );
-    appointmentCounts.push(snapshot.size);
-  }
+      last7Days.push(
+        date.toLocaleDateString('es', { weekday: 'short', day: 'numeric' })
+      );
+      appointmentCounts.push(snapshot.size);
+    }
 
-  if (appointmentsChart) appointmentsChart.destroy();
-  appointmentsChart = new Chart(ctx1, {
-    type: 'line',
-    data: {
-      labels: last7Days,
-      datasets: [
-        {
-          label: 'Citas',
-          data: appointmentCounts,
-          borderColor: '#16A34A',
-          backgroundColor: 'rgba(22, 163, 74, 0.1)',
-          tension: 0.1,
-        },
-      ],
-    },
-    options: {
-      responsive: true,
-      plugins: {
-        legend: { display: false },
+    if (appointmentsChart) appointmentsChart.destroy();
+    appointmentsChart = new Chart(ctx1, {
+      type: 'line',
+      data: {
+        labels: last7Days,
+        datasets: [
+          {
+            label: 'Citas',
+            data: appointmentCounts,
+            borderColor: '#16A34A',
+            backgroundColor: 'rgba(22, 163, 74, 0.1)',
+            tension: 0.1,
+          },
+        ],
       },
-    },
-  });
-
-  // Services chart
-  const servicesData = {};
-  const appointmentsSnapshot = await db.collection('appointments').get();
-
-  appointmentsSnapshot.forEach((doc) => {
-    const service = doc.data().service || 'Sin servicio';
-    servicesData[service] = (servicesData[service] || 0) + 1;
-  });
-
-  const ctx2 = document.getElementById('servicesChart').getContext('2d');
-
-  if (servicesChart) servicesChart.destroy();
-  servicesChart = new Chart(ctx2, {
-    type: 'doughnut',
-    data: {
-      labels: Object.keys(servicesData),
-      datasets: [
-        {
-          data: Object.values(servicesData),
-          backgroundColor: [
-            '#16A34A',
-            '#15803d',
-            '#166534',
-            '#14532d',
-            '#052e16',
-          ],
-        },
-      ],
-    },
-    options: {
-      responsive: true,
-      plugins: {
-        legend: {
-          position: 'bottom',
+      options: {
+        responsive: true,
+        plugins: {
+          legend: { display: false },
         },
       },
-    },
-  });
+    });
+
+    // Services chart
+    const servicesData = {};
+    const appointmentsSnapshot = await db.collection('appointments').get();
+
+    appointmentsSnapshot.forEach((doc) => {
+      const service = doc.data().service || 'Sin servicio';
+      servicesData[service] = (servicesData[service] || 0) + 1;
+    });
+
+    const ctx2 = document.getElementById('servicesChart').getContext('2d');
+
+    if (servicesChart) servicesChart.destroy();
+    servicesChart = new Chart(ctx2, {
+      type: 'doughnut',
+      data: {
+        labels: Object.keys(servicesData),
+        datasets: [
+          {
+            data: Object.values(servicesData),
+            backgroundColor: [
+              '#16A34A',
+              '#15803d',
+              '#166534',
+              '#14532d',
+              '#052e16',
+            ],
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        plugins: {
+          legend: {
+            position: 'bottom',
+          },
+        },
+      },
+    });
   } catch (error) {
     Logger.error('Error loading charts:', error);
     showNotification('Error al cargar las gráficas', 'error');
@@ -370,7 +369,7 @@ function toggleCalendarView() {
     tableView.style.display = 'none';
     toggleText.textContent = 'Ver Tabla';
 
-    if (!calendar) {
+    if (!calendarUtils.getCalendar('main')) {
       initializeCalendar();
     }
     loadCalendarEvents();
@@ -385,14 +384,7 @@ function toggleCalendarView() {
 function initializeCalendar() {
   const calendarEl = document.getElementById('calendar');
 
-  calendar = new FullCalendar.Calendar(calendarEl, {
-    initialView: 'dayGridMonth',
-    locale: 'es',
-    headerToolbar: {
-      left: 'prev,next today',
-      center: 'title',
-      right: 'dayGridMonth,timeGridWeek,timeGridDay',
-    },
+  calendarUtils.createCalendar('main', calendarEl, {
     events: [],
     eventClick: function (info) {
       viewAppointmentDetails(info.event.id);
@@ -400,15 +392,14 @@ function initializeCalendar() {
     dateClick: function (info) {
       showAddAppointmentForDate(info.dateStr);
     },
-    height: 'auto',
   });
-
-  calendar.render();
 }
 
 // Load calendar events
 async function loadCalendarEvents() {
   try {
+    const calendar = calendarUtils.getCalendar('main');
+    if (!calendar) return;
     const snapshot = await db.collection('appointments').get();
     const events = [];
 
@@ -595,21 +586,24 @@ async function loadPatients() {
       // First, let's get appointment counts for each patient
       const appointmentsSnapshot = await db.collection('appointments').get();
       const patientAppointments = {};
-      
+
       appointmentsSnapshot.forEach((doc) => {
         const apt = doc.data();
         if (apt.patientId) {
           if (!patientAppointments[apt.patientId]) {
             patientAppointments[apt.patientId] = {
               count: 0,
-              lastVisit: null
+              lastVisit: null,
             };
           }
           patientAppointments[apt.patientId].count++;
-          
+
           const aptDate = apt.date ? new Date(apt.date.seconds * 1000) : null;
-          if (aptDate && (!patientAppointments[apt.patientId].lastVisit || 
-              aptDate > patientAppointments[apt.patientId].lastVisit)) {
+          if (
+            aptDate &&
+            (!patientAppointments[apt.patientId].lastVisit ||
+              aptDate > patientAppointments[apt.patientId].lastVisit)
+          ) {
             patientAppointments[apt.patientId].lastVisit = aptDate;
           }
         }
@@ -620,11 +614,16 @@ async function loadPatients() {
         const birthDate = patient.birthDate || 'N/A';
         const gender = patient.gender || patient.genero || '-';
         const phone = patient.phone || '';
-        
+
         // Get appointment info for this patient
-        const aptInfo = patientAppointments[doc.id] || { count: 0, lastVisit: null };
-        const lastVisit = aptInfo.lastVisit ? aptInfo.lastVisit.toLocaleDateString() : '-';
-        
+        const aptInfo = patientAppointments[doc.id] || {
+          count: 0,
+          lastVisit: null,
+        };
+        const lastVisit = aptInfo.lastVisit
+          ? aptInfo.lastVisit.toLocaleDateString()
+          : '-';
+
         const row = `
                     <tr>
                         <td>${patient.name || patient.displayName || 'N/A'}</td>
@@ -707,12 +706,20 @@ async function loadServices() {
           : null;
 
         // Handle different field name variations
-        const serviceName = service.name || service.serviceName || service.nombre || doc.id || 'N/A';
-        const serviceCategory = service.category || service.categoria || service.type || 'General';
-        const serviceDuration = service.duration || service.duracion || service.sessionDuration || 60;
-        const servicePrice = service.price || service.precio || service.cost || 0;
+        const serviceName =
+          service.name ||
+          service.serviceName ||
+          service.nombre ||
+          doc.id ||
+          'N/A';
+        const serviceCategory =
+          service.category || service.categoria || service.type || 'General';
+        const serviceDuration =
+          service.duration || service.duracion || service.sessionDuration || 60;
+        const servicePrice =
+          service.price || service.precio || service.cost || 0;
         const isActive = service.active !== undefined ? service.active : true;
-        
+
         const row = `
                     <tr>
                         <td>${serviceName}</td>
@@ -742,73 +749,73 @@ async function loadServices() {
 async function addDefaultServices() {
   try {
     const defaultServices = [
-    {
-      id: 'yoga',
-      name: 'Yoga Terapéutico',
-      category: 'Bienestar',
-      duration: 60,
-      price: 40,
-      active: true,
-      isGroupService: true,
-      maxParticipants: 16,
-      hasCapacityManagement: true,
-    },
-    {
-      id: 'massage',
-      name: 'Masajes',
-      category: 'Bienestar',
-      duration: 60,
-      price: 80,
-      active: true,
-      isGroupService: false,
-      maxParticipants: 1,
-      hasCapacityManagement: true,
-    },
-    {
-      id: 'sauna',
-      name: 'Sauna y Baño Helado',
-      category: 'Bienestar',
-      duration: 45,
-      price: 50,
-      active: true,
-      isGroupService: false,
-      maxParticipants: 1,
-      hasCapacityManagement: true,
-    },
-    {
-      id: 'hyperbaric',
-      name: 'Cámara Hiperbárica',
-      category: 'Medicina',
-      duration: 90,
-      price: 120,
-      active: true,
-      isGroupService: false,
-      maxParticipants: 1,
-      hasCapacityManagement: true,
-    },
-    {
-      id: 'iv_therapy',
-      name: 'Sueros IV',
-      category: 'Medicina',
-      duration: 45,
-      price: 100,
-      active: true,
-      isGroupService: true,
-      maxParticipants: 5,
-      hasCapacityManagement: true,
-    },
-  ];
+      {
+        id: 'yoga',
+        name: 'Yoga Terapéutico',
+        category: 'Bienestar',
+        duration: 60,
+        price: 40,
+        active: true,
+        isGroupService: true,
+        maxParticipants: 16,
+        hasCapacityManagement: true,
+      },
+      {
+        id: 'massage',
+        name: 'Masajes',
+        category: 'Bienestar',
+        duration: 60,
+        price: 80,
+        active: true,
+        isGroupService: false,
+        maxParticipants: 1,
+        hasCapacityManagement: true,
+      },
+      {
+        id: 'sauna',
+        name: 'Sauna y Baño Helado',
+        category: 'Bienestar',
+        duration: 45,
+        price: 50,
+        active: true,
+        isGroupService: false,
+        maxParticipants: 1,
+        hasCapacityManagement: true,
+      },
+      {
+        id: 'hyperbaric',
+        name: 'Cámara Hiperbárica',
+        category: 'Medicina',
+        duration: 90,
+        price: 120,
+        active: true,
+        isGroupService: false,
+        maxParticipants: 1,
+        hasCapacityManagement: true,
+      },
+      {
+        id: 'iv_therapy',
+        name: 'Sueros IV',
+        category: 'Medicina',
+        duration: 45,
+        price: 100,
+        active: true,
+        isGroupService: true,
+        maxParticipants: 5,
+        hasCapacityManagement: true,
+      },
+    ];
 
-  for (const service of defaultServices) {
-    const { id, ...serviceData } = service;
-    await db
-      .collection('services')
-      .doc(id)
-      .set({
-        ...serviceData,
-        createdAt: firebase.firestore.FieldValue.serverTimestamp(),
-      });
-  }
+    for (const service of defaultServices) {
+      const { id, ...serviceData } = service;
+      await db
+        .collection('services')
+        .doc(id)
+        .set({
+          ...serviceData,
+          createdAt: firebase.firestore.FieldValue.serverTimestamp(),
+        });
+    }
 
     loadServices(); // Reload the table
   } catch (error) {
@@ -856,8 +863,8 @@ async function showServiceCalendar(serviceId, serviceName) {
     const serviceDoc = await db.collection('services').doc(serviceId).get();
     const service = serviceDoc.data();
 
-  // Create calendar content
-  modalBody.innerHTML = `
+    // Create calendar content
+    modalBody.innerHTML = `
         <div style="margin-bottom: 20px;">
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <div>
@@ -890,13 +897,13 @@ async function showServiceCalendar(serviceId, serviceName) {
         <div id="serviceCalendarContainer" style="background: white; padding: 20px; border-radius: 8px; min-height: 600px;"></div>
     `;
 
-  // Show modal
-  modal.classList.add('active');
+    // Show modal
+    modal.classList.add('active');
 
-  // Initialize calendar after modal is shown
-  setTimeout(() => {
-    initializeCalendarForService(serviceId, service);
-  }, 100);
+    // Initialize calendar after modal is shown
+    setTimeout(() => {
+      initializeCalendarForService(serviceId, service);
+    }, 100);
   } catch (error) {
     Logger.error('Error showing service calendar:', error);
     showNotification('Error al mostrar el calendario del servicio', 'error');
@@ -913,96 +920,99 @@ async function initializeCalendarForService(serviceId, serviceData) {
 
     // Get appointments for this service
     const appointmentsSnapshot = await db
-    .collection('appointments')
-    .where('serviceId', '==', serviceId)
-    .where('date', '>=', new Date())
-    .get();
+      .collection('appointments')
+      .where('serviceId', '==', serviceId)
+      .where('date', '>=', new Date())
+      .get();
 
-  const events = [];
-  const slotCounts = {}; // Track bookings per slot
+    const events = [];
+    const slotCounts = {}; // Track bookings per slot
 
-  appointmentsSnapshot.forEach((doc) => {
-    const appointment = doc.data();
-    const date = appointment.date.toDate();
-    const dateStr = date.toISOString().split('T')[0];
-    const timeKey = `${dateStr}_${appointment.time || appointment.startTime}`;
+    appointmentsSnapshot.forEach((doc) => {
+      const appointment = doc.data();
+      const date = appointment.date.toDate();
+      const dateStr = date.toISOString().split('T')[0];
+      const timeKey = `${dateStr}_${appointment.time || appointment.startTime}`;
 
-    // Count bookings per slot
-    slotCounts[timeKey] = (slotCounts[timeKey] || 0) + 1;
+      // Count bookings per slot
+      slotCounts[timeKey] = (slotCounts[timeKey] || 0) + 1;
 
-    // Create event
-    const startTime = appointment.time || appointment.startTime || '09:00';
-    const [hours, minutes] = startTime.split(':');
-    const start = new Date(date);
-    start.setHours(parseInt(hours), parseInt(minutes));
+      // Create event
+      const startTime = appointment.time || appointment.startTime || '09:00';
+      const [hours, minutes] = startTime.split(':');
+      const start = new Date(date);
+      start.setHours(parseInt(hours), parseInt(minutes));
 
-    const end = new Date(start);
-    end.setMinutes(end.getMinutes() + (serviceData.duration || 60));
+      const end = new Date(start);
+      end.setMinutes(end.getMinutes() + (serviceData.duration || 60));
 
-    events.push({
-      id: doc.id,
-      title: appointment.patientName || appointment.userName || 'Reservado',
-      start: start,
-      end: end,
-      extendedProps: {
-        appointmentId: doc.id,
-        patientId: appointment.patientId || appointment.userId,
-        status: appointment.status,
-        phone: appointment.userPhone,
+      events.push({
+        id: doc.id,
+        title: appointment.patientName || appointment.userName || 'Reservado',
+        start: start,
+        end: end,
+        extendedProps: {
+          appointmentId: doc.id,
+          patientId: appointment.patientId || appointment.userId,
+          status: appointment.status,
+          phone: appointment.userPhone,
+        },
+      });
+    });
+
+    // Create calendar
+    window.currentCalendarInstance = new FullCalendar.Calendar(calendarEl, {
+      initialView: 'timeGridWeek',
+      locale: 'es',
+      height: 600,
+      headerToolbar: {
+        left: 'prev,next today',
+        center: 'title',
+        right: 'dayGridMonth,timeGridWeek,timeGridDay',
+      },
+      slotMinTime: '06:00:00',
+      slotMaxTime: '21:00:00',
+      slotDuration: '00:30:00',
+      expandRows: true,
+      events: events,
+
+      eventClick: function (info) {
+        showAppointmentDetails(info.event.extendedProps.appointmentId);
+      },
+
+      dateClick: function (info) {
+        // Create new appointment slot
+        createServiceSlot(serviceId, info.date);
+      },
+
+      eventDidMount: function (info) {
+        // Color based on capacity
+        const dateStr = info.event.start.toISOString().split('T')[0];
+        const timeStr = info.event.start.toTimeString().slice(0, 5);
+        const timeKey = `${dateStr}_${timeStr}`;
+        const booked = slotCounts[timeKey] || 0;
+        const capacity = serviceData.maxParticipants || 1;
+
+        if (booked >= capacity) {
+          info.el.style.backgroundColor = '#DC2626'; // Red - full
+        } else if (booked >= capacity * 0.8) {
+          info.el.style.backgroundColor = '#F59E0B'; // Yellow - almost full
+        } else {
+          info.el.style.backgroundColor = '#16A34A'; // Green - available
+        }
+
+        // Add tooltip
+        info.el.title = `${booked}/${capacity} reservados`;
       },
     });
-  });
-
-  // Create calendar
-  window.currentCalendarInstance = new FullCalendar.Calendar(calendarEl, {
-    initialView: 'timeGridWeek',
-    locale: 'es',
-    height: 600,
-    headerToolbar: {
-      left: 'prev,next today',
-      center: 'title',
-      right: 'dayGridMonth,timeGridWeek,timeGridDay',
-    },
-    slotMinTime: '06:00:00',
-    slotMaxTime: '21:00:00',
-    slotDuration: '00:30:00',
-    expandRows: true,
-    events: events,
-
-    eventClick: function (info) {
-      showAppointmentDetails(info.event.extendedProps.appointmentId);
-    },
-
-    dateClick: function (info) {
-      // Create new appointment slot
-      createServiceSlot(serviceId, info.date);
-    },
-
-    eventDidMount: function (info) {
-      // Color based on capacity
-      const dateStr = info.event.start.toISOString().split('T')[0];
-      const timeStr = info.event.start.toTimeString().slice(0, 5);
-      const timeKey = `${dateStr}_${timeStr}`;
-      const booked = slotCounts[timeKey] || 0;
-      const capacity = serviceData.maxParticipants || 1;
-
-      if (booked >= capacity) {
-        info.el.style.backgroundColor = '#DC2626'; // Red - full
-      } else if (booked >= capacity * 0.8) {
-        info.el.style.backgroundColor = '#F59E0B'; // Yellow - almost full
-      } else {
-        info.el.style.backgroundColor = '#16A34A'; // Green - available
-      }
-
-      // Add tooltip
-      info.el.title = `${booked}/${capacity} reservados`;
-    },
-  });
 
     window.currentCalendarInstance.render();
   } catch (error) {
     Logger.error('Error initializing calendar for service:', error);
-    showNotification('Error al inicializar el calendario del servicio', 'error');
+    showNotification(
+      'Error al inicializar el calendario del servicio',
+      'error'
+    );
   }
 }
 
@@ -1299,35 +1309,34 @@ function viewPatient(id) {
 async function showAddAppointment(preselectedDate = null) {
   try {
     // Get lists for dropdowns
-    const [patientsSnapshot, staffSnapshot, servicesSnapshot] = await Promise.all(
-    [
-      db.collection('users').where('role', '==', 'patient').get(),
-      db.collection('staff').where('active', '==', true).get(),
-      db.collection('services').where('active', '==', true).get(),
-    ]
-  );
+    const [patientsSnapshot, staffSnapshot, servicesSnapshot] =
+      await Promise.all([
+        db.collection('users').where('role', '==', 'patient').get(),
+        db.collection('staff').where('active', '==', true).get(),
+        db.collection('services').where('active', '==', true).get(),
+      ]);
 
-  let patientsOptions = '<option value="">Seleccionar paciente</option>';
-  patientsSnapshot.forEach((doc) => {
-    const patient = doc.data();
-    patientsOptions += `<option value="${doc.id}">${patient.name || patient.email}</option>`;
-  });
+    let patientsOptions = '<option value="">Seleccionar paciente</option>';
+    patientsSnapshot.forEach((doc) => {
+      const patient = doc.data();
+      patientsOptions += `<option value="${doc.id}">${patient.name || patient.email}</option>`;
+    });
 
-  let staffOptions = '<option value="">Seleccionar profesional</option>';
-  staffSnapshot.forEach((doc) => {
-    const staff = doc.data();
-    staffOptions += `<option value="${doc.id}">${staff.name} (${staff.role})</option>`;
-  });
+    let staffOptions = '<option value="">Seleccionar profesional</option>';
+    staffSnapshot.forEach((doc) => {
+      const staff = doc.data();
+      staffOptions += `<option value="${doc.id}">${staff.name} (${staff.role})</option>`;
+    });
 
-  let servicesOptions = '<option value="">Seleccionar servicio</option>';
-  servicesSnapshot.forEach((doc) => {
-    const service = doc.data();
-    servicesOptions += `<option value="${doc.id}">${service.name} - ${service.duration}min - $${service.price}</option>`;
-  });
+    let servicesOptions = '<option value="">Seleccionar servicio</option>';
+    servicesSnapshot.forEach((doc) => {
+      const service = doc.data();
+      servicesOptions += `<option value="${doc.id}">${service.name} - ${service.duration}min - $${service.price}</option>`;
+    });
 
-  const today = preselectedDate || new Date().toISOString().split('T')[0];
+    const today = preselectedDate || new Date().toISOString().split('T')[0];
 
-  const content = `
+    const content = `
         <form id="addAppointmentForm">
             <div class="form-group">
                 <label>Paciente</label>
@@ -1365,81 +1374,85 @@ async function showAddAppointment(preselectedDate = null) {
         </div>
     `;
 
-  showModal('Nueva Cita', content);
+    showModal('Nueva Cita', content);
 
-  document
-    .getElementById('addAppointmentForm')
-    .addEventListener('submit', async (e) => {
-      e.preventDefault();
-      const formData = new FormData(e.target);
+    document
+      .getElementById('addAppointmentForm')
+      .addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const formData = new FormData(e.target);
 
-      try {
-        const serviceId = formData.get('serviceId');
-        const date = new Date(formData.get('date'));
-        const time = formData.get('time');
-        const patientId = formData.get('patientId');
+        try {
+          const serviceId = formData.get('serviceId');
+          const date = new Date(formData.get('date'));
+          const time = formData.get('time');
+          const patientId = formData.get('patientId');
 
-        // Validate booking if service has capacity management
-        if (
-          window.serviceCapacity &&
-          window.serviceCapacity.SERVICE_CAPACITY[serviceId]
-        ) {
-          const validation = await window.serviceCapacity.validateBooking(
-            serviceId,
-            date,
-            time,
-            patientId
-          );
+          // Validate booking if service has capacity management
+          if (
+            window.serviceCapacity &&
+            window.serviceCapacity.SERVICE_CAPACITY[serviceId]
+          ) {
+            const validation = await window.serviceCapacity.validateBooking(
+              serviceId,
+              date,
+              time,
+              patientId
+            );
 
-          if (!validation.valid) {
-            alert(`No se puede agendar la cita: ${validation.reason}`);
-            return;
+            if (!validation.valid) {
+              alert(`No se puede agendar la cita: ${validation.reason}`);
+              return;
+            }
           }
-        }
 
-        // Get selected data
-        const patientDoc = await db.collection('users').doc(patientId).get();
-        const staffDoc = await db
-          .collection('staff')
-          .doc(formData.get('staffId'))
-          .get();
-        const serviceDoc = await db.collection('services').doc(serviceId).get();
+          // Get selected data
+          const patientDoc = await db.collection('users').doc(patientId).get();
+          const staffDoc = await db
+            .collection('staff')
+            .doc(formData.get('staffId'))
+            .get();
+          const serviceDoc = await db
+            .collection('services')
+            .doc(serviceId)
+            .get();
 
-        const appointmentData = {
-          patientId: patientId,
-          patientName: patientDoc.data().name || patientDoc.data().email,
-          patientPhone: patientDoc.data().phone || '',
-          staffId: formData.get('staffId'),
-          staffName: staffDoc.data().name,
-          serviceId: serviceId,
-          service: serviceDoc.data().name,
-          date: firebase.firestore.Timestamp.fromDate(date),
-          time: time,
-          notes: formData.get('notes'),
-          status: 'pendiente',
-          createdAt: firebase.firestore.FieldValue.serverTimestamp(),
-          createdBy: currentUser.uid,
-        };
+          const appointmentData = {
+            patientId: patientId,
+            patientName: patientDoc.data().name || patientDoc.data().email,
+            patientPhone: patientDoc.data().phone || '',
+            staffId: formData.get('staffId'),
+            staffName: staffDoc.data().name,
+            serviceId: serviceId,
+            service: serviceDoc.data().name,
+            date: firebase.firestore.Timestamp.fromDate(date),
+            time: time,
+            notes: formData.get('notes'),
+            status: 'pendiente',
+            createdAt: firebase.firestore.FieldValue.serverTimestamp(),
+            createdBy: currentUser.uid,
+          };
 
-        await db.collection('appointments').add(appointmentData);
+          await db.collection('appointments').add(appointmentData);
 
-        closeModal();
+          closeModal();
 
-        // Reload appointments
-        if (
-          document.getElementById('appointments').classList.contains('active')
-        ) {
-          loadAppointments();
-          if (calendar) {
-            loadCalendarEvents();
+          // Reload appointments
+          if (
+            document.getElementById('appointments').classList.contains('active')
+          ) {
+            loadAppointments();
+            const calendar = calendarUtils.getCalendar('main');
+            if (calendar) {
+              loadCalendarEvents();
+            }
           }
-        }
 
-        alert('Cita agendada exitosamente');
-      } catch (error) {
-        alert('Error al agendar cita: ' + error.message);
-      }
-    });
+          alert('Cita agendada exitosamente');
+        } catch (error) {
+          alert('Error al agendar cita: ' + error.message);
+        }
+      });
   } catch (error) {
     Logger.error('Error showing add appointment modal:', error);
     showNotification('Error al mostrar el formulario de cita', 'error');
@@ -1687,30 +1700,30 @@ async function loadPayments() {
 async function createSamplePayments() {
   try {
     const samplePayments = [
-    {
-      patientName: 'Juan Pérez',
-      service: 'Consulta Médica',
-      amount: 50,
-      method: 'Efectivo',
-      status: 'pagado',
-      date: firebase.firestore.Timestamp.now(),
-    },
-    {
-      patientName: 'María García',
-      service: 'Terapia Psicológica',
-      amount: 80,
-      method: 'Tarjeta',
-      status: 'pendiente',
-      date: firebase.firestore.Timestamp.now(),
-    },
-  ];
+      {
+        patientName: 'Juan Pérez',
+        service: 'Consulta Médica',
+        amount: 50,
+        method: 'Efectivo',
+        status: 'pagado',
+        date: firebase.firestore.Timestamp.now(),
+      },
+      {
+        patientName: 'María García',
+        service: 'Terapia Psicológica',
+        amount: 80,
+        method: 'Tarjeta',
+        status: 'pendiente',
+        date: firebase.firestore.Timestamp.now(),
+      },
+    ];
 
-  for (const payment of samplePayments) {
-    await db.collection('payments').add({
-      ...payment,
-      createdAt: firebase.firestore.FieldValue.serverTimestamp(),
-    });
-  }
+    for (const payment of samplePayments) {
+      await db.collection('payments').add({
+        ...payment,
+        createdAt: firebase.firestore.FieldValue.serverTimestamp(),
+      });
+    }
 
     loadPayments();
   } catch (error) {
@@ -1723,23 +1736,23 @@ async function createSamplePayments() {
 async function showAddPayment() {
   try {
     const [patientsSnapshot, servicesSnapshot] = await Promise.all([
-    db.collection('users').where('role', '==', 'patient').get(),
-    db.collection('services').where('active', '==', true).get(),
-  ]);
+      db.collection('users').where('role', '==', 'patient').get(),
+      db.collection('services').where('active', '==', true).get(),
+    ]);
 
-  let patientsOptions = '<option value="">Seleccionar paciente</option>';
-  patientsSnapshot.forEach((doc) => {
-    const patient = doc.data();
-    patientsOptions += `<option value="${doc.id}">${patient.name || patient.email}</option>`;
-  });
+    let patientsOptions = '<option value="">Seleccionar paciente</option>';
+    patientsSnapshot.forEach((doc) => {
+      const patient = doc.data();
+      patientsOptions += `<option value="${doc.id}">${patient.name || patient.email}</option>`;
+    });
 
-  let servicesOptions = '<option value="">Seleccionar servicio</option>';
-  servicesSnapshot.forEach((doc) => {
-    const service = doc.data();
-    servicesOptions += `<option value="${doc.id}" data-price="${service.price}">${service.name} - $${service.price}</option>`;
-  });
+    let servicesOptions = '<option value="">Seleccionar servicio</option>';
+    servicesSnapshot.forEach((doc) => {
+      const service = doc.data();
+      servicesOptions += `<option value="${doc.id}" data-price="${service.price}">${service.name} - $${service.price}</option>`;
+    });
 
-  const content = `
+    const content = `
         <form id="addPaymentForm">
             <div class="form-group">
                 <label>Paciente</label>
@@ -1771,46 +1784,46 @@ async function showAddPayment() {
         </form>
     `;
 
-  showModal('Registrar Pago', content);
+    showModal('Registrar Pago', content);
 
-  document
-    .getElementById('addPaymentForm')
-    .addEventListener('submit', async (e) => {
-      e.preventDefault();
-      const formData = new FormData(e.target);
+    document
+      .getElementById('addPaymentForm')
+      .addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const formData = new FormData(e.target);
 
-      try {
-        const patientDoc = await db
-          .collection('users')
-          .doc(formData.get('patientId'))
-          .get();
-        const serviceDoc = await db
-          .collection('services')
-          .doc(formData.get('serviceId'))
-          .get();
+        try {
+          const patientDoc = await db
+            .collection('users')
+            .doc(formData.get('patientId'))
+            .get();
+          const serviceDoc = await db
+            .collection('services')
+            .doc(formData.get('serviceId'))
+            .get();
 
-        const paymentData = {
-          patientId: formData.get('patientId'),
-          patientName: patientDoc.data().name || patientDoc.data().email,
-          serviceId: formData.get('serviceId'),
-          service: serviceDoc.data().name,
-          amount: parseFloat(formData.get('amount')),
-          method: formData.get('method'),
-          notes: formData.get('notes'),
-          status: 'pagado',
-          date: firebase.firestore.Timestamp.now(),
-          createdAt: firebase.firestore.FieldValue.serverTimestamp(),
-          createdBy: currentUser.uid,
-        };
+          const paymentData = {
+            patientId: formData.get('patientId'),
+            patientName: patientDoc.data().name || patientDoc.data().email,
+            serviceId: formData.get('serviceId'),
+            service: serviceDoc.data().name,
+            amount: parseFloat(formData.get('amount')),
+            method: formData.get('method'),
+            notes: formData.get('notes'),
+            status: 'pagado',
+            date: firebase.firestore.Timestamp.now(),
+            createdAt: firebase.firestore.FieldValue.serverTimestamp(),
+            createdBy: currentUser.uid,
+          };
 
-        await db.collection('payments').add(paymentData);
-        closeModal();
-        loadPayments();
-        alert('Pago registrado exitosamente');
-      } catch (error) {
-        alert('Error al registrar pago: ' + error.message);
-      }
-    });
+          await db.collection('payments').add(paymentData);
+          closeModal();
+          loadPayments();
+          alert('Pago registrado exitosamente');
+        } catch (error) {
+          alert('Error al registrar pago: ' + error.message);
+        }
+      });
   } catch (error) {
     Logger.error('Error showing add payment modal:', error);
     showNotification('Error al mostrar el formulario de pago', 'error');
@@ -2217,12 +2230,12 @@ async function testPushNotification() {
 
     // Log test notification
     await db.collection('notifications').add({
-    type: 'Push - Prueba',
-    recipient: 'Todos los usuarios',
-    message: 'Notificación de prueba desde el panel admin',
-    status: 'enviado',
-    createdAt: firebase.firestore.FieldValue.serverTimestamp(),
-  });
+      type: 'Push - Prueba',
+      recipient: 'Todos los usuarios',
+      message: 'Notificación de prueba desde el panel admin',
+      status: 'enviado',
+      createdAt: firebase.firestore.FieldValue.serverTimestamp(),
+    });
 
     loadNotifications();
   } catch (error) {
@@ -4105,47 +4118,47 @@ async function checkExpiringProducts() {
     thirtyDaysFromNow.setDate(thirtyDaysFromNow.getDate() + 30);
 
     const expiringProducts = await db
-    .collection('products')
-    .where('trackExpiry', '==', true)
-    .where('expiryDate', '<=', thirtyDaysFromNow)
-    .where('stock', '>', 0)
-    .get();
+      .collection('products')
+      .where('trackExpiry', '==', true)
+      .where('expiryDate', '<=', thirtyDaysFromNow)
+      .where('stock', '>', 0)
+      .get();
 
-  const alerts = [];
-  expiringProducts.forEach((doc) => {
-    const product = doc.data();
-    const expiryDate = new Date(product.expiryDate.seconds * 1000);
-    const daysToExpiry = Math.floor(
-      (expiryDate - new Date()) / (1000 * 60 * 60 * 24)
-    );
+    const alerts = [];
+    expiringProducts.forEach((doc) => {
+      const product = doc.data();
+      const expiryDate = new Date(product.expiryDate.seconds * 1000);
+      const daysToExpiry = Math.floor(
+        (expiryDate - new Date()) / (1000 * 60 * 60 * 24)
+      );
 
-    alerts.push({
-      productName: product.name,
-      expiryDate: expiryDate.toLocaleDateString(),
-      daysToExpiry: daysToExpiry,
-      stock: product.stock,
-      id: doc.id,
+      alerts.push({
+        productName: product.name,
+        expiryDate: expiryDate.toLocaleDateString(),
+        daysToExpiry: daysToExpiry,
+        stock: product.stock,
+        id: doc.id,
+      });
     });
-  });
 
-  // Send WhatsApp alerts if configured
-  const whatsappConfig = await getWhatsAppConfig();
-  if (whatsappConfig && alerts.length > 0) {
-    const whatsapp = new WhatsAppAutomation(whatsappConfig);
+    // Send WhatsApp alerts if configured
+    const whatsappConfig = await getWhatsAppConfig();
+    if (whatsappConfig && alerts.length > 0) {
+      const whatsapp = new WhatsAppAutomation(whatsappConfig);
 
-    // Send to admin
-    const adminPhone = whatsappConfig.adminPhone || currentUser.phone;
-    if (adminPhone) {
-      const message = `⚠️ *Productos próximos a vencer*\n\n${alerts
-        .map(
-          (a) =>
-            `• ${a.productName}\n  Vence: ${a.expiryDate} (${a.daysToExpiry} días)\n  Stock: ${a.stock} unidades`
-        )
-        .join('\n\n')}`;
+      // Send to admin
+      const adminPhone = whatsappConfig.adminPhone || currentUser.phone;
+      if (adminPhone) {
+        const message = `⚠️ *Productos próximos a vencer*\n\n${alerts
+          .map(
+            (a) =>
+              `• ${a.productName}\n  Vence: ${a.expiryDate} (${a.daysToExpiry} días)\n  Stock: ${a.stock} unidades`
+          )
+          .join('\n\n')}`;
 
-      await whatsapp.sendMessage(adminPhone, message);
+        await whatsapp.sendMessage(adminPhone, message);
+      }
     }
-  }
 
     return alerts;
   } catch (error) {
@@ -4320,64 +4333,64 @@ async function sendWhatsAppMessages() {
 
     document.getElementById('whatsappLoading').style.display = 'block';
 
-  let recipients = [];
+    let recipients = [];
 
-  // Get recipients based on type
-  switch (type) {
-    case 'single':
-      const phone = document.getElementById('phoneNumber').value;
-      if (phone) recipients.push({ phone, name: 'Usuario' });
-      break;
+    // Get recipients based on type
+    switch (type) {
+      case 'single':
+        const phone = document.getElementById('phoneNumber').value;
+        if (phone) recipients.push({ phone, name: 'Usuario' });
+        break;
 
-    case 'custom':
-      const customNumbers = document
-        .getElementById('customNumbersList')
-        .value.split('\n')
-        .filter((n) => n.trim())
-        .map((n) => ({ phone: n.trim(), name: 'Usuario' }));
-      recipients = customNumbers;
-      break;
+      case 'custom':
+        const customNumbers = document
+          .getElementById('customNumbersList')
+          .value.split('\n')
+          .filter((n) => n.trim())
+          .map((n) => ({ phone: n.trim(), name: 'Usuario' }));
+        recipients = customNumbers;
+        break;
 
-    case 'group':
-      const checkboxes = document.querySelectorAll(
-        '#patientsList input[type="checkbox"]:checked'
-      );
-      checkboxes.forEach((cb) => {
-        if (cb.value) {
-          const patient = whatsappPatients.find((p) => p.phone === cb.value);
-          recipients.push({
-            phone: cb.value,
-            name: patient?.name || 'Paciente',
-          });
-        }
-      });
-      break;
+      case 'group':
+        const checkboxes = document.querySelectorAll(
+          '#patientsList input[type="checkbox"]:checked'
+        );
+        checkboxes.forEach((cb) => {
+          if (cb.value) {
+            const patient = whatsappPatients.find((p) => p.phone === cb.value);
+            recipients.push({
+              phone: cb.value,
+              name: patient?.name || 'Paciente',
+            });
+          }
+        });
+        break;
 
-    case 'all':
-      recipients = whatsappPatients
-        .filter((p) => p.phone)
-        .map((p) => ({
-          phone: p.phone,
-          name: p.name || 'Paciente',
-        }));
-      break;
-  }
+      case 'all':
+        recipients = whatsappPatients
+          .filter((p) => p.phone)
+          .map((p) => ({
+            phone: p.phone,
+            name: p.name || 'Paciente',
+          }));
+        break;
+    }
 
-  if (recipients.length === 0) {
-    alert('No hay destinatarios seleccionados');
+    if (recipients.length === 0) {
+      alert('No hay destinatarios seleccionados');
+      document.getElementById('whatsappLoading').style.display = 'none';
+      return;
+    }
+
+    // Send messages
+    for (const recipient of recipients) {
+      await sendSingleWhatsAppMessage(recipient, message);
+      // Wait between messages
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+
     document.getElementById('whatsappLoading').style.display = 'none';
-    return;
-  }
-
-  // Send messages
-  for (const recipient of recipients) {
-    await sendSingleWhatsAppMessage(recipient, message);
-    // Wait between messages
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-  }
-
-  document.getElementById('whatsappLoading').style.display = 'none';
-  updateWhatsAppStats();
+    updateWhatsAppStats();
   } catch (error) {
     Logger.error('Error sending WhatsApp messages:', error);
     showNotification('Error al enviar mensajes de WhatsApp', 'error');
@@ -4389,10 +4402,10 @@ async function sendWhatsAppMessages() {
 async function sendSingleWhatsAppMessage(recipient, message) {
   try {
     const personalizedMessage = message
-    .replace('{nombre}', recipient.name)
-    .replace('{fecha}', new Date().toLocaleDateString())
-    .replace('{hora}', '10:00 AM')
-    .replace('{doctor}', 'Dr. Martínez');
+      .replace('{nombre}', recipient.name)
+      .replace('{fecha}', new Date().toLocaleDateString())
+      .replace('{hora}', '10:00 AM')
+      .replace('{doctor}', 'Dr. Martínez');
     // Save to Firebase
     const logEntry = {
       to: recipient.phone,

--- a/calendar/utils.js
+++ b/calendar/utils.js
@@ -1,0 +1,48 @@
+(function (global) {
+  const calendars = {};
+
+  function createCalendar(id, element, options = {}) {
+    if (!element) {
+      console.error('Calendar element not found for id', id);
+      return null;
+    }
+    const defaultOptions = {
+      initialView: 'dayGridMonth',
+      locale: 'es',
+      headerToolbar: {
+        left: 'prev,next today',
+        center: 'title',
+        right: 'dayGridMonth,timeGridWeek,timeGridDay',
+      },
+      editable: true,
+      droppable: true,
+      eventDurationEditable: false,
+      height: 'auto',
+    };
+    const calendar = new FullCalendar.Calendar(element, {
+      ...defaultOptions,
+      ...options,
+    });
+    calendar.render();
+    calendars[id] = calendar;
+    return calendar;
+  }
+
+  function getCalendar(id) {
+    return calendars[id] || null;
+  }
+
+  function destroyCalendar(id) {
+    const calendar = calendars[id];
+    if (calendar) {
+      calendar.destroy();
+      delete calendars[id];
+    }
+  }
+
+  global.calendarUtils = {
+    createCalendar,
+    getCalendar,
+    destroyCalendar,
+  };
+})(window);

--- a/index.html
+++ b/index.html
@@ -2050,6 +2050,7 @@ _Responde STOP para no recibir más mensajes_</textarea
 
     <script src="logger.js"></script>
     <script src="config.js"></script>
+    <script src="calendar/utils.js"></script>
     <script src="app.js"></script>
     <script src="service_capacity.js"></script>
     <script src="service_calendar.js"></script>

--- a/service_calendar.js
+++ b/service_calendar.js
@@ -1,7 +1,6 @@
 // Service Calendar Management
 // Handles individual calendar views, drag-and-drop scheduling, and recurring class management
 
-let serviceCalendars = {};
 let currentServiceId = null;
 let draggedEvent = null;
 
@@ -22,7 +21,7 @@ async function initializeServiceCalendar(serviceId, containerId) {
           duration: serviceData.duration || 60,
           type: serviceData.isGroupService ? 'group' : 'individual',
           minTimeBetween: 15,
-          price: serviceData.price || 0
+          price: serviceData.price || 0,
         };
         // Store in SERVICE_CAPACITY for future use
         window.serviceCapacity.SERVICE_CAPACITY[serviceId] = serviceConfig;
@@ -39,20 +38,13 @@ async function initializeServiceCalendar(serviceId, containerId) {
 
   // For now, skip the availability panel to test if calendar loads
   console.log('Creating calendar for element:', calendarEl);
-  
+
   // Temporarily comment out the panel
   // const calendarContainer = addAvailabilityPanel(calendarEl, serviceId);
-  
+
   try {
-    const calendar = new FullCalendar.Calendar(calendarEl, {
-      initialView: 'dayGridMonth',
-      locale: 'es',
+    const calendar = calendarUtils.createCalendar(serviceId, calendarEl, {
       height: 600,
-      headerToolbar: {
-        left: 'prev,next today',
-        center: 'title',
-        right: 'dayGridMonth,timeGridWeek,timeGridDay',
-      },
       // businessHours: getBusinessHours(serviceId),
       slotMinTime: '06:00:00',
       slotMaxTime: '21:00:00',
@@ -60,103 +52,96 @@ async function initializeServiceCalendar(serviceId, containerId) {
       slotLabelInterval: '01:00:00',
       expandRows: true,
 
-    // Enable drag and drop
-    editable: true,
-    droppable: true,
-    eventDurationEditable: false,
+      // Custom event rendering
+      eventDidMount: function (info) {
+        const event = info.event;
+        const el = info.el;
 
-    // Custom event rendering
-    eventDidMount: function (info) {
-      const event = info.event;
-      const el = info.el;
+        // Add capacity info
+        const capacity = event.extendedProps.capacity || serviceConfig.capacity;
+        const booked = event.extendedProps.booked || 0;
+        const available = capacity - booked;
 
-      // Add capacity info
-      const capacity = event.extendedProps.capacity || serviceConfig.capacity;
-      const booked = event.extendedProps.booked || 0;
-      const available = capacity - booked;
+        // Color coding based on availability
+        if (available === 0) {
+          el.style.backgroundColor = '#DC2626'; // Red - full
+          el.style.borderColor = '#991B1B';
+        } else if (available <= capacity * 0.25) {
+          el.style.backgroundColor = '#F59E0B'; // Yellow - almost full
+          el.style.borderColor = '#D97706';
+        } else {
+          el.style.backgroundColor = '#16A34A'; // Green - available
+          el.style.borderColor = '#15803D';
+        }
 
-      // Color coding based on availability
-      if (available === 0) {
-        el.style.backgroundColor = '#DC2626'; // Red - full
-        el.style.borderColor = '#991B1B';
-      } else if (available <= capacity * 0.25) {
-        el.style.backgroundColor = '#F59E0B'; // Yellow - almost full
-        el.style.borderColor = '#D97706';
-      } else {
-        el.style.backgroundColor = '#16A34A'; // Green - available
-        el.style.borderColor = '#15803D';
-      }
+        // Add tooltip
+        el.setAttribute(
+          'title',
+          `${serviceConfig.name}\nCapacidad: ${booked}/${capacity}\nDisponible: ${available}`
+        );
+      },
 
-      // Add tooltip
-      el.setAttribute(
-        'title',
-        `${serviceConfig.name}\nCapacidad: ${booked}/${capacity}\nDisponible: ${available}`
-      );
-    },
+      // Event click handler
+      eventClick: function (info) {
+        showServiceEventDetails(info.event);
+      },
 
-    // Event click handler
-    eventClick: function (info) {
-      showServiceEventDetails(info.event);
-    },
+      // Date click handler (for creating new events)
+      dateClick: function (info) {
+        if (
+          info.view.type === 'timeGridWeek' ||
+          info.view.type === 'timeGridDay'
+        ) {
+          showCreateServiceEvent(serviceId, info.date);
+        }
+      },
 
-    // Date click handler (for creating new events)
-    dateClick: function (info) {
-      if (
-        info.view.type === 'timeGridWeek' ||
-        info.view.type === 'timeGridDay'
-      ) {
-        showCreateServiceEvent(serviceId, info.date);
-      }
-    },
+      // Drag start
+      eventDragStart: function (info) {
+        draggedEvent = info.event;
+      },
 
-    // Drag start
-    eventDragStart: function (info) {
-      draggedEvent = info.event;
-    },
+      // Drop handler
+      eventDrop: async function (info) {
+        const confirmed = confirm(
+          `¿Mover ${info.event.title} a ${info.event.start.toLocaleString('es')}?`
+        );
 
-    // Drop handler
-    eventDrop: async function (info) {
-      const confirmed = confirm(
-        `¿Mover ${info.event.title} a ${info.event.start.toLocaleString('es')}?`
-      );
+        if (!confirmed) {
+          info.revert();
+          return;
+        }
 
-      if (!confirmed) {
-        info.revert();
-        return;
-      }
+        try {
+          await updateServiceEvent(info.event);
+        } catch (error) {
+          Logger.error('Error updating event:', error);
+          info.revert();
+          alert('Error al actualizar el evento');
+        }
+      },
 
-      try {
-        await updateServiceEvent(info.event);
-      } catch (error) {
-        Logger.error('Error updating event:', error);
-        info.revert();
-        alert('Error al actualizar el evento');
-      }
-    },
+      // External event drop
+      drop: async function (info) {
+        if (draggedEvent) {
+          const newDate = info.date;
+          await createServiceEventFromDrop(serviceId, draggedEvent, newDate);
+          draggedEvent = null;
+        }
+      },
 
-    // External event drop
-    drop: async function (info) {
-      if (draggedEvent) {
-        const newDate = info.date;
-        await createServiceEventFromDrop(serviceId, draggedEvent, newDate);
-        draggedEvent = null;
-      }
-    },
+      // Simple test events
+      events: [
+        {
+          title: 'Test Event',
+          start: new Date(),
+          backgroundColor: '#16A34A',
+        },
+      ],
+    });
 
-    // Simple test events
-    events: [
-      {
-        title: 'Test Event',
-        start: new Date(),
-        backgroundColor: '#16A34A'
-      }
-    ]
-  });
-
-    calendar.render();
-    serviceCalendars[serviceId] = calendar;
     currentServiceId = serviceId;
-    
+
     console.log('Calendar rendered successfully');
     return calendar;
   } catch (error) {
@@ -465,7 +450,10 @@ function showCreateServiceEvent(serviceId, date) {
       try {
         await createServiceEvent(serviceId, formData);
         closeModal();
-        serviceCalendars[serviceId].refetchEvents();
+        const calendar = calendarUtils.getCalendar(serviceId);
+        if (calendar) {
+          calendar.refetchEvents();
+        }
       } catch (error) {
         alert('Error al crear el evento: ' + error.message);
       }
@@ -611,7 +599,7 @@ async function loadStaffOptions(serviceId) {
 async function showServiceCalendar(serviceId) {
   // Try to get service config from predefined services
   let serviceConfig = window.serviceCapacity.SERVICE_CAPACITY[serviceId];
-  
+
   // If not found, get from Firestore
   if (!serviceConfig) {
     try {
@@ -623,7 +611,7 @@ async function showServiceCalendar(serviceId) {
           capacity: serviceData.maxParticipants || serviceData.capacity || 1,
           duration: serviceData.duration || 60,
           type: serviceData.isGroupService ? 'group' : 'individual',
-          price: serviceData.price || 0
+          price: serviceData.price || 0,
         };
       } else {
         alert('Servicio no encontrado');
@@ -782,8 +770,9 @@ function showServiceSettings(serviceId) {
         closeModal();
 
         // Refresh calendar
-        if (serviceCalendars[serviceId]) {
-          serviceCalendars[serviceId].refetchEvents();
+        const calendar = calendarUtils.getCalendar(serviceId);
+        if (calendar) {
+          calendar.refetchEvents();
         }
       } catch (error) {
         alert('Error al actualizar configuración: ' + error.message);
@@ -889,7 +878,7 @@ function createServiceStatsChart(stats) {
 // Export service schedule
 function exportServiceSchedule(serviceId) {
   const serviceConfig = window.serviceCapacity.SERVICE_CAPACITY[serviceId];
-  const calendar = serviceCalendars[serviceId];
+  const calendar = calendarUtils.getCalendar(serviceId);
 
   if (!calendar) {
     alert('Por favor abre el calendario primero');
@@ -1032,8 +1021,9 @@ async function cancelServiceSlot(serviceId, date, time) {
     closeModal();
 
     // Refresh calendar
-    if (serviceCalendars[serviceId]) {
-      serviceCalendars[serviceId].refetchEvents();
+    const calendar = calendarUtils.getCalendar(serviceId);
+    if (calendar) {
+      calendar.refetchEvents();
     }
   } catch (error) {
     Logger.error('Error cancelling service slot:', error);
@@ -1044,19 +1034,21 @@ async function cancelServiceSlot(serviceId, date, time) {
 // Add availability panel to calendar view
 function addAvailabilityPanel(calendarEl, serviceId) {
   const serviceConfig = window.serviceCapacity.SERVICE_CAPACITY[serviceId];
-  
+
   if (!serviceConfig) {
     Logger.error('Service config not found for:', serviceId);
     return calendarEl; // Return original element if no config
   }
-  
+
   // Create wrapper for calendar and panel
   const wrapper = document.createElement('div');
-  wrapper.style.cssText = 'display: grid; grid-template-columns: 300px 1fr; gap: 20px; height: 100%;';
-  
+  wrapper.style.cssText =
+    'display: grid; grid-template-columns: 300px 1fr; gap: 20px; height: 100%;';
+
   // Create availability panel
   const panel = document.createElement('div');
-  panel.style.cssText = 'background: #f8f9fa; padding: 20px; border-radius: 8px; overflow-y: auto;';
+  panel.style.cssText =
+    'background: #f8f9fa; padding: 20px; border-radius: 8px; overflow-y: auto;';
   panel.innerHTML = `
     <h3 style="margin-top: 0; color: #1e3a3f;">📊 Disponibilidad</h3>
     
@@ -1101,24 +1093,25 @@ function addAvailabilityPanel(calendarEl, serviceId) {
       <div style="font-size: 13px;">Cargando...</div>
     </div>
   `;
-  
+
   // Create calendar container
   const calendarContainer = document.createElement('div');
   calendarContainer.id = calendarEl.id + '_calendar';
-  calendarContainer.style.cssText = 'background: white; padding: 20px; border-radius: 8px;';
-  
+  calendarContainer.style.cssText =
+    'background: white; padding: 20px; border-radius: 8px;';
+
   // Replace original element
   calendarEl.innerHTML = '';
   wrapper.appendChild(panel);
   wrapper.appendChild(calendarContainer);
   calendarEl.appendChild(wrapper);
-  
+
   // Update calendar element reference
   calendarEl = calendarContainer;
-  
+
   // Load initial stats
   updateAvailabilityPanel(serviceId);
-  
+
   return calendarContainer;
 }
 
@@ -1127,8 +1120,11 @@ async function updateAvailabilityPanel(serviceId) {
   try {
     // Get today's availability
     const today = new Date();
-    const availability = await window.serviceCapacity.getServiceAvailability(serviceId, today);
-    
+    const availability = await window.serviceCapacity.getServiceAvailability(
+      serviceId,
+      today
+    );
+
     // Update quick stats
     const statsEl = document.getElementById(`quickStats_${serviceId}`);
     if (statsEl) {
@@ -1143,22 +1139,29 @@ async function updateAvailabilityPanel(serviceId) {
         </div>
       `;
     }
-    
+
     // Update today's availability
     const todayEl = document.getElementById(`todayAvailability_${serviceId}`);
     if (todayEl && availability.slots) {
-      let slotsHtml = '<h4 style="font-size: 14px; color: #666; margin: 0 0 10px 0;">Disponibilidad Hoy</h4>';
-      
-      const availableSlots = availability.slots.filter(s => s.enabled && s.available > 0);
-      
+      let slotsHtml =
+        '<h4 style="font-size: 14px; color: #666; margin: 0 0 10px 0;">Disponibilidad Hoy</h4>';
+
+      const availableSlots = availability.slots.filter(
+        (s) => s.enabled && s.available > 0
+      );
+
       if (availableSlots.length === 0) {
-        slotsHtml += '<p style="font-size: 13px; color: #DC2626;">No hay cupos disponibles para hoy</p>';
+        slotsHtml +=
+          '<p style="font-size: 13px; color: #DC2626;">No hay cupos disponibles para hoy</p>';
       } else {
-        slotsHtml += '<div style="display: flex; flex-direction: column; gap: 5px;">';
-        availableSlots.forEach(slot => {
-          const percentage = Math.round((slot.available / slot.totalCapacity) * 100);
+        slotsHtml +=
+          '<div style="display: flex; flex-direction: column; gap: 5px;">';
+        availableSlots.forEach((slot) => {
+          const percentage = Math.round(
+            (slot.available / slot.totalCapacity) * 100
+          );
           const color = percentage > 25 ? '#16A34A' : '#F59E0B';
-          
+
           slotsHtml += `
             <div style="display: flex; justify-content: space-between; align-items: center; padding: 8px; background: #f8f9fa; border-radius: 4px;">
               <span style="font-size: 13px;">${slot.time}</span>
@@ -1173,7 +1176,7 @@ async function updateAvailabilityPanel(serviceId) {
         });
         slotsHtml += '</div>';
       }
-      
+
       todayEl.innerHTML = slotsHtml;
     }
   } catch (error) {
@@ -1187,11 +1190,11 @@ async function getWeekStats(serviceId) {
   const startOfWeek = new Date();
   startOfWeek.setDate(startOfWeek.getDate() - startOfWeek.getDay());
   startOfWeek.setHours(0, 0, 0, 0);
-  
+
   const endOfWeek = new Date(startOfWeek);
   endOfWeek.setDate(endOfWeek.getDate() + 6);
   endOfWeek.setHours(23, 59, 59, 999);
-  
+
   try {
     const snapshot = await db
       .collection('appointments')
@@ -1199,11 +1202,11 @@ async function getWeekStats(serviceId) {
       .where('date', '>=', firebase.firestore.Timestamp.fromDate(startOfWeek))
       .where('date', '<=', firebase.firestore.Timestamp.fromDate(endOfWeek))
       .get();
-    
+
     let totalBooked = 0;
     let classCount = {};
-    
-    snapshot.forEach(doc => {
+
+    snapshot.forEach((doc) => {
       const data = doc.data();
       const key = `${data.date.toDate().toDateString()}_${data.time}`;
       if (!classCount[key]) {
@@ -1212,18 +1215,19 @@ async function getWeekStats(serviceId) {
       classCount[key]++;
       totalBooked++;
     });
-    
+
     const totalClasses = Object.keys(classCount).length;
     const totalCapacity = totalClasses * serviceConfig.capacity;
-    const avgOccupancy = totalCapacity > 0 ? Math.round((totalBooked / totalCapacity) * 100) : 0;
+    const avgOccupancy =
+      totalCapacity > 0 ? Math.round((totalBooked / totalCapacity) * 100) : 0;
     const estimatedRevenue = totalBooked * (serviceConfig.price || 50);
-    
+
     return {
       totalClasses,
       totalCapacity,
       totalBooked,
       avgOccupancy,
-      estimatedRevenue
+      estimatedRevenue,
     };
   } catch (error) {
     Logger.error('Error getting week stats:', error);
@@ -1232,7 +1236,7 @@ async function getWeekStats(serviceId) {
       totalCapacity: 0,
       totalBooked: 0,
       avgOccupancy: 0,
-      estimatedRevenue: 0
+      estimatedRevenue: 0,
     };
   }
 }


### PR DESCRIPTION
## Summary
- centralize FullCalendar instantiation in new `calendar/utils` module with default options and instance management
- use shared calendar manager in `app.js` and `service_calendar.js` to remove global state
- include common utility in HTML to load before calendar-dependent scripts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run format:check` *(fails: Code style issues found in 5 files)*


------
https://chatgpt.com/codex/tasks/task_e_689563ebc89c832b9de05faf3baf865d