### PR TITLE
feat: add themed calendar event icons

### DIFF
--- a/calendar_enhancements.js
+++ b/calendar_enhancements.js
@@ -372,6 +372,7 @@ const CALENDAR_CONFIG = {
   dayMaxEvents: true,
   weekNumbers: true,
   weekText: 'Sem',
+  themeSystem: 'bootstrap5',
   businessHours: {
     daysOfWeek: [1, 2, 3, 4, 5, 6], // Monday - Saturday
     startTime: '06:00',
@@ -387,6 +388,23 @@ const CALENDAR_CONFIG = {
     hour: '2-digit',
     minute: '2-digit',
     meridiem: false,
+  },
+  eventContent: function (arg) {
+    const status = arg.event.extendedProps.status;
+    const capacity = arg.event.extendedProps.capacity;
+    const booked = arg.event.extendedProps.booked || 0;
+    const available = capacity != null ? capacity - booked : null;
+
+    let iconClass = 'fa-circle-check';
+    if (status === 'cancelado') {
+      iconClass = 'fa-circle-xmark';
+    } else if (available === 0) {
+      iconClass = 'fa-circle-exclamation';
+    }
+
+    const icon = `<i class="fa-solid ${iconClass} me-1"></i>`;
+    const timeText = arg.timeText ? arg.timeText + ' ' : '';
+    return { html: `${icon}${timeText}${arg.event.title}` };
   },
 };
 
@@ -827,25 +845,22 @@ function enhanceEventDisplay(info, serviceConfig) {
   const event = info.event;
   const el = info.el;
 
-  // Add capacity info if available
-  if (serviceConfig) {
-    const capacity = event.extendedProps.capacity || serviceConfig.capacity;
-    const booked = event.extendedProps.booked || 0;
-    const available = capacity - booked;
+  const capacity =
+    event.extendedProps.capacity || (serviceConfig && serviceConfig.capacity);
+  const booked = event.extendedProps.booked || 0;
+  const available = capacity != null ? capacity - booked : null;
 
-    // Color coding based on availability
-    if (available === 0) {
-      el.style.backgroundColor = '#DC2626'; // Red - full
-      el.style.borderColor = '#991B1B';
-    } else if (available <= capacity * 0.25) {
-      el.style.backgroundColor = '#F59E0B'; // Yellow - almost full
-      el.style.borderColor = '#D97706';
-    } else {
-      el.style.backgroundColor = '#16A34A'; // Green - available
-      el.style.borderColor = '#15803D';
-    }
+  el.classList.remove('event-available', 'event-full', 'event-canceled');
 
-    // Add capacity badge
+  if (event.extendedProps.status === 'cancelado') {
+    el.classList.add('event-canceled');
+  } else if (available === 0 && capacity != null) {
+    el.classList.add('event-full');
+  } else {
+    el.classList.add('event-available');
+  }
+
+  if (capacity != null) {
     const badge = document.createElement('span');
     badge.className = 'event-capacity-badge';
     badge.textContent = `${booked}/${capacity}`;
@@ -1598,6 +1613,12 @@ window.showServiceCalendar = function (serviceId) {
 function addCalendarStyles() {
   const style = document.createElement('style');
   style.textContent = `
+        :root {
+            --event-available: #16A34A;
+            --event-full: #F59E0B;
+            --event-canceled: #DC2626;
+        }
+
         /* Flatpickr enhancements */
         .flatpickr-calendar {
             box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
@@ -1636,7 +1657,23 @@ function addCalendarStyles() {
             transform: translateY(-2px);
             box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
         }
-        
+
+        .event-available {
+            background: var(--event-available) !important;
+            border-color: var(--event-available) !important;
+        }
+
+        .event-full {
+            background: var(--event-full) !important;
+            border-color: var(--event-full) !important;
+        }
+
+        .event-canceled {
+            background: var(--event-canceled) !important;
+            border-color: var(--event-canceled) !important;
+            text-decoration: line-through;
+        }
+
         .event-capacity-badge {
             font-weight: bold;
         }

--- a/index.html
+++ b/index.html
@@ -4,10 +4,24 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Healing Forest Admin</title>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
+    />
     <script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-app-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-auth-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-firestore-compat.js"></script>
     <style>
+      :root {
+        --event-available: #16a34a;
+        --event-full: #f59e0b;
+        --event-canceled: #dc2626;
+      }
+
       * {
         margin: 0;
         padding: 0;
@@ -19,6 +33,22 @@
           -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
         background: #f5f5f5;
         color: #333;
+      }
+
+      .event-available {
+        background-color: var(--event-available) !important;
+        border-color: var(--event-available) !important;
+      }
+
+      .event-full {
+        background-color: var(--event-full) !important;
+        border-color: var(--event-full) !important;
+      }
+
+      .event-canceled {
+        background-color: var(--event-canceled) !important;
+        border-color: var(--event-canceled) !important;
+        text-decoration: line-through;
       }
 
       /* Login Screen */
@@ -2069,7 +2099,9 @@ _Responde STOP para no recibir más mensajes_</textarea
       rel="stylesheet"
     />
     <script src="https://cdn.jsdelivr.net/npm/fullcalendar@5.11.3/main.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/bootstrap5@5.11.3/main.global.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/fullcalendar@5.11.3/locales/es.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 
     <!-- jsPDF para generar PDFs -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>


### PR DESCRIPTION
## Summary
- enable Bootstrap theme and status color classes for FullCalendar
- add FontAwesome icons in event content
- load Bootstrap and FullCalendar Bootstrap plugin

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run format:check` (fails: Code style issues found in 7 files)


------
https://chatgpt.com/codex/tasks/task_e_6895647b30ec832ba1d87bd2a5bed9b9