### PR TITLE
Add recurring event series controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Panel administrativo para gestionar citas, pagos y servicios de Healing Forest.
 ## 🚀 Deploy Automático
 
 Este proyecto se actualiza automáticamente en:
+
 - **URL**: https://healing-forest-admin.netlify.app
 
 Cada vez que se hace un cambio en GitHub, se actualiza automáticamente en la web.
@@ -31,3 +32,10 @@ Cada vez que se hace un cambio en GitHub, se actualiza automáticamente en la we
 - Chart.js para gráficas
 - FullCalendar para calendario
 - jsPDF para reportes
+
+## 🔁 Recurrencia de eventos
+
+Al crear una nueva clase desde el calendario se puede elegir una opción de **Repetir** (diario, semanal o mensual) y definir una fecha de finalización.
+El sistema generará todos los eventos correspondientes en Firestore mediante una operación en lote, agrupados bajo un mismo `seriesId`.
+
+En el modal de detalles de cualquier evento de la serie aparecerán los botones **Editar serie** y **Cancelar serie**, que permiten actualizar o eliminar todas las ocurrencias de la serie con un solo clic.


### PR DESCRIPTION
## Summary
- handle repeated events with a shared `seriesId`
- load and display manual slots, enabling editing or cancellation of whole series
- document recurrence options in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run format:check`
- `npm run check:console`


------
https://chatgpt.com/codex/tasks/task_e_6895647b4670832bad2ad66139d0f0e5